### PR TITLE
Build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ dependencies {
         implementation 'com.unboundid.product.scim2:scim2-sdk-client:2.3.5'
         // Don't upgrade h2database
         runtimeOnly "com.h2database:h2:2.3.232"
-        runtimeOnly "org.postgresql:postgresql:42.7.4"
+        runtimeOnly "org.postgresql:postgresql:42.7.5"
         constraints {
             implementation "org.opensaml:opensaml-core:$openSamlVersion"
             implementation "org.opensaml:opensaml-saml-api:$openSamlVersion"


### PR DESCRIPTION
## without `./gradlew clean dependencies buildEnvironment spotlessApply --write-verification-metadata sha256 --refresh-dependencies`

## without `./gradlew clean dependencies buildEnvironment spotlessApply --write-verification-metadata sha256,pgp --refresh-keys --export-keys --refresh-dependencies`
